### PR TITLE
bugfix: 打开设置页的时候优先读取localStorage（原来是优先读取了navLang）

### DIFF
--- a/src/locale/index.js
+++ b/src/locale/index.js
@@ -13,7 +13,7 @@ Vue.use(VueI18n)
 // 自动根据浏览器系统语言设置语言
 const navLang = navigator.language
 const localLang = (navLang === 'zh-CN' || navLang === 'en-US' || navLang === 'zh-TW') ? navLang : false
-let lang = localLang || localRead('local') || 'zh-CN'
+let lang = localRead('local') || localLang || 'zh-CN'
 
 Vue.config.lang = lang
 


### PR DESCRIPTION
原框架也有类似问题

https://github.com/iview/iview-admin/blob/dd86e386a8542e8808a54ce7afeb713963c81d3c/src/locale/index.js#L16